### PR TITLE
Add JWT login and frontend auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ EstateMap is a modern web platform that allows real estate companies to list and
 
 The repository contains a React frontend built with Vite and a Django backend exposed via a REST API. Docker is provided to run the full stack along with a PostgreSQL database.
 
+The backend uses JWT tokens for authentication. Obtain a token by POSTing your credentials to `/api/login/` and include the returned token in the `Authorization` header (`Bearer <token>`) for protected endpoints.
+
 ### Prerequisites
 
 - [Docker](https://www.docker.com/)

--- a/backend/real_estate/serializers.py
+++ b/backend/real_estate/serializers.py
@@ -1,7 +1,28 @@
 from rest_framework import serializers
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from django.contrib.auth.models import User
 from .models import Property
 
 class PropertySerializer(serializers.ModelSerializer):
     class Meta:
         model = Property
         fields = '__all__'
+
+
+class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
+    """Return token along with basic user information."""
+
+    @classmethod
+    def get_token(cls, user):
+        token = super().get_token(user)
+        token["username"] = user.username
+        return token
+
+    def validate(self, attrs):
+        data = super().validate(attrs)
+        data["user"] = {
+            "id": self.user.id,
+            "username": self.user.username,
+            "email": self.user.email,
+        }
+        return data

--- a/backend/real_estate/urls.py
+++ b/backend/real_estate/urls.py
@@ -1,7 +1,12 @@
 from rest_framework.routers import DefaultRouter
-from .views import PropertyViewSet
+from django.urls import path
+from .views import PropertyViewSet, CustomTokenObtainPairView
 
 router = DefaultRouter()
 router.register('properties', PropertyViewSet)
 
-urlpatterns = router.urls
+urlpatterns = [
+    path('login/', CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),
+]
+
+urlpatterns += router.urls

--- a/backend/real_estate/views.py
+++ b/backend/real_estate/views.py
@@ -1,7 +1,14 @@
 from rest_framework import viewsets
+from rest_framework_simplejwt.views import TokenObtainPairView
+from rest_framework.permissions import IsAuthenticated
 from .models import Property
-from .serializers import PropertySerializer
+from .serializers import PropertySerializer, CustomTokenObtainPairSerializer
 
 class PropertyViewSet(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
     queryset = Property.objects.all()
     serializer_class = PropertySerializer
+
+
+class CustomTokenObtainPairView(TokenObtainPairView):
+    serializer_class = CustomTokenObtainPairSerializer

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,11 +1,21 @@
 import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import MapPage from './pages/MapPage';
+import Login from './pages/Login';
+import PrivateRoute from './PrivateRoute';
 
 const App = () => (
   <Routes>
     <Route path="/" element={<Home />} />
-    <Route path="/map" element={<MapPage />} />
+    <Route path="/login" element={<Login />} />
+    <Route
+      path="/map"
+      element={(
+        <PrivateRoute>
+          <MapPage />
+        </PrivateRoute>
+      )}
+    />
   </Routes>
 );
 

--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+
+  const login = (newToken, remember) => {
+    if (remember) {
+      localStorage.setItem('token', newToken);
+    } else {
+      sessionStorage.setItem('token', newToken);
+    }
+    setToken(newToken);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    sessionStorage.removeItem('token');
+    setToken(null);
+  };
+
+  useEffect(() => {
+    const stored = localStorage.getItem('token') || sessionStorage.getItem('token');
+    if (stored) setToken(stored);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/PrivateRoute.jsx
+++ b/frontend/src/PrivateRoute.jsx
@@ -1,0 +1,9 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from './AuthContext';
+
+const PrivateRoute = ({ children }) => {
+  const { token } = useAuth();
+  return token ? children : <Navigate to="/login" replace />;
+};
+
+export default PrivateRoute;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,11 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { AuthProvider } from './AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,7 +1,23 @@
-const Home = () => (
-  <div>
-    <h1>Welcome to EstateMap</h1>
-  </div>
-);
+import { Link } from 'react-router-dom';
+import { Button } from '@mui/material';
+import { useAuth } from '../AuthContext';
+
+const Home = () => {
+  const { token } = useAuth();
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Welcome to EstateMap</h1>
+      {token ? (
+        <Button component={Link} to="/map" variant="contained" sx={{ mt: 2 }}>
+          Ir al Mapa
+        </Button>
+      ) : (
+        <Button component={Link} to="/login" variant="contained" sx={{ mt: 2 }}>
+          Iniciar Sesión
+        </Button>
+      )}
+    </div>
+  );
+};
 
 export default Home;

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { TextField, Button, Checkbox, FormControlLabel, Box, Typography, CircularProgress } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
+
+const Login = () => {
+  const navigate = useNavigate();
+  const { login } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [remember, setRemember] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await fetch('/api/login/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (!res.ok) throw new Error('Credenciales incorrectas');
+      const data = await res.json();
+      login(data.access, remember);
+      navigate('/map');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: 400, mx: 'auto', mt: 8, p: 2 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Iniciar Sesión
+      </Typography>
+      <form onSubmit={handleSubmit}>
+        <TextField
+          label="Usuario"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          fullWidth
+          margin="normal"
+          required
+        />
+        <TextField
+          label="Contraseña"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          fullWidth
+          margin="normal"
+          required
+        />
+        <FormControlLabel
+          control={<Checkbox checked={remember} onChange={(e) => setRemember(e.target.checked)} />}
+          label="Recordar sesión"
+        />
+        {error && (
+          <Typography color="error" sx={{ mt: 1 }}>
+            {error}
+          </Typography>
+        )}
+        <Box sx={{ position: 'relative', mt: 2 }}>
+          <Button type="submit" variant="contained" fullWidth disabled={loading}>
+            Entrar
+          </Button>
+          {loading && (
+            <CircularProgress size={24} sx={{ position: 'absolute', top: '50%', left: '50%', mt: '-12px', ml: '-12px' }} />
+          )}
+        </Box>
+      </form>
+    </Box>
+  );
+};
+
+export default Login;

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -1,15 +1,23 @@
 import { MapContainer, TileLayer } from 'react-leaflet';
+import { Button } from '@mui/material';
 import 'leaflet/dist/leaflet.css';
+import { useAuth } from '../AuthContext';
 
-const MapPage = () => (
-  <div style={{ height: '100vh' }}>
-    <MapContainer center={[0, 0]} zoom={13} style={{ height: '100%' }}>
-      <TileLayer
-        attribution='&copy; OpenStreetMap contributors'
-        url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
-      />
-    </MapContainer>
-  </div>
-);
+const MapPage = () => {
+  const { logout } = useAuth();
+  return (
+    <div style={{ height: '100vh', position: 'relative' }}>
+      <Button onClick={logout} variant="contained" sx={{ position: 'absolute', top: 16, right: 16, zIndex: 1000 }}>
+        Logout
+      </Button>
+      <MapContainer center={[0, 0]} zoom={13} style={{ height: '100%' }}>
+        <TileLayer
+          attribution='&copy; OpenStreetMap contributors'
+          url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+        />
+      </MapContainer>
+    </div>
+  );
+};
 
 export default MapPage;


### PR DESCRIPTION
## Summary
- secure API with JWT and require authentication for properties
- create login endpoint using Simple JWT with extended info
- show login, logout and protected map view in frontend
- add authentication context
- document JWT usage in README

## Testing
- `python -m compileall -q .`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855bf504e3083259a2b005dbd98941c