### PR TITLE
Implement user registration flow

### DIFF
--- a/backend/real_estate/serializers.py
+++ b/backend/real_estate/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from django.contrib.auth.models import User
+from django.contrib.auth.password_validation import validate_password
 from .models import Property
 
 class PropertySerializer(serializers.ModelSerializer):
@@ -26,3 +27,20 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
             "email": self.user.email,
         }
         return data
+
+
+class RegisterSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True, required=True, validators=[validate_password])
+
+    class Meta:
+        model = User
+        fields = ("username", "email", "password")
+
+    def create(self, validated_data):
+        user = User.objects.create_user(
+            username=validated_data["username"],
+            email=validated_data.get("email", ""),
+            password=validated_data["password"],
+        )
+        return user
+

--- a/backend/real_estate/urls.py
+++ b/backend/real_estate/urls.py
@@ -1,12 +1,13 @@
 from rest_framework.routers import DefaultRouter
 from django.urls import path
-from .views import PropertyViewSet, CustomTokenObtainPairView
+from .views import PropertyViewSet, CustomTokenObtainPairView, RegisterView
 
 router = DefaultRouter()
 router.register('properties', PropertyViewSet)
 
 urlpatterns = [
     path('login/', CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('register/', RegisterView.as_view(), name='register'),
 ]
 
 urlpatterns += router.urls

--- a/backend/real_estate/views.py
+++ b/backend/real_estate/views.py
@@ -1,8 +1,13 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, generics
 from rest_framework_simplejwt.views import TokenObtainPairView
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
 from .models import Property
-from .serializers import PropertySerializer, CustomTokenObtainPairSerializer
+from django.contrib.auth.models import User
+from .serializers import (
+    PropertySerializer,
+    CustomTokenObtainPairSerializer,
+    RegisterSerializer,
+)
 
 class PropertyViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
@@ -12,3 +17,9 @@ class PropertyViewSet(viewsets.ModelViewSet):
 
 class CustomTokenObtainPairView(TokenObtainPairView):
     serializer_class = CustomTokenObtainPairSerializer
+
+
+class RegisterView(generics.CreateAPIView):
+    queryset = User.objects.all()
+    serializer_class = RegisterSerializer
+    permission_classes = [AllowAny]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,12 +2,14 @@ import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import MapPage from './pages/MapPage';
 import Login from './pages/Login';
+import Register from './pages/Register';
 import PrivateRoute from './PrivateRoute';
 
 const App = () => (
   <Routes>
     <Route path="/" element={<Home />} />
     <Route path="/login" element={<Login />} />
+    <Route path="/register" element={<Register />} />
     <Route
       path="/map"
       element={(

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,27 +1,41 @@
 import { Link } from 'react-router-dom';
-import { Button } from '@mui/material';
+import { AppBar, Toolbar, Typography, Button } from '@mui/material';
 import { useAuth } from '../AuthContext';
 
 const Home = () => {
   const { token } = useAuth();
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Welcome to EstateMap</h1>
-      {token ? (
-        <Button component={Link} to="/map" variant="contained" sx={{ mt: 2 }}>
-          Ir al Mapa
-        </Button>
-      ) : (
-        <>
-          <Button component={Link} to="/login" variant="contained" sx={{ mt: 2, mr: 2 }}>
-            Iniciar Sesión
+    <>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            EstateMap
+          </Typography>
+          {!token && (
+            <Button color="inherit" component={Link} to="/login">
+              Iniciar Sesión
+            </Button>
+          )}
+        </Toolbar>
+      </AppBar>
+      <div style={{ padding: '2rem' }}>
+        <h1>Welcome to EstateMap</h1>
+        {token ? (
+          <Button component={Link} to="/map" variant="contained" sx={{ mt: 2 }}>
+            Ir al Mapa
           </Button>
-          <Button component={Link} to="/register" variant="outlined" sx={{ mt: 2 }}>
-            Registrarse
-          </Button>
-        </>
-      )}
-    </div>
+        ) : (
+          <>
+            <Button component={Link} to="/login" variant="contained" sx={{ mt: 2, mr: 2 }}>
+              Iniciar Sesión
+            </Button>
+            <Button component={Link} to="/register" variant="outlined" sx={{ mt: 2 }}>
+              Registrarse
+            </Button>
+          </>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -12,9 +12,14 @@ const Home = () => {
           Ir al Mapa
         </Button>
       ) : (
-        <Button component={Link} to="/login" variant="contained" sx={{ mt: 2 }}>
-          Iniciar Sesión
-        </Button>
+        <>
+          <Button component={Link} to="/login" variant="contained" sx={{ mt: 2, mr: 2 }}>
+            Iniciar Sesión
+          </Button>
+          <Button component={Link} to="/register" variant="outlined" sx={{ mt: 2 }}>
+            Registrarse
+          </Button>
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -74,10 +74,9 @@ const Login = () => {
           )}
         </Box>
       </form>
-      <Typography variant="body2" sx={{ mt: 2 }}>
-        ¿No tienes cuenta?{' '}
-        <Link to="/register">Regístrate</Link>
-      </Typography>
+      <Button component={Link} to="/register" fullWidth sx={{ mt: 2 }}>
+        Registrarse
+      </Button>
     </Box>
   );
 };

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -17,7 +17,7 @@ const Login = () => {
     setError(null);
     setLoading(true);
     try {
-      const res = await fetch('/api/login/', {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/login/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -22,14 +22,14 @@ const Register = () => {
     setError(null);
     setLoading(true);
     try {
-      const res = await fetch('/api/register/', {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/register/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, email, password })
       });
       if (!res.ok) throw new Error('Error al registrar');
       // login automatically
-      const loginRes = await fetch('/api/login/', {
+      const loginRes = await fetch(`${import.meta.env.VITE_API_URL}/login/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,30 +1,42 @@
 import { useState } from 'react';
-import { TextField, Button, Checkbox, FormControlLabel, Box, Typography, CircularProgress } from '@mui/material';
+import { TextField, Button, Box, Typography, CircularProgress } from '@mui/material';
 import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 
-const Login = () => {
+const Register = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
   const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [remember, setRemember] = useState(false);
+  const [confirm, setConfirm] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (password !== confirm) {
+      setError('Las contraseñas no coinciden');
+      return;
+    }
     setError(null);
     setLoading(true);
     try {
-      const res = await fetch('/api/login/', {
+      const res = await fetch('/api/register/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, email, password })
+      });
+      if (!res.ok) throw new Error('Error al registrar');
+      // login automatically
+      const loginRes = await fetch('/api/login/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })
       });
-      if (!res.ok) throw new Error('Credenciales incorrectas');
-      const data = await res.json();
-      login(data.access, remember);
+      if (!loginRes.ok) throw new Error('Registro completado pero fallo el login');
+      const data = await loginRes.json();
+      login(data.access, true);
       navigate('/map');
     } catch (err) {
       setError(err.message);
@@ -36,7 +48,7 @@ const Login = () => {
   return (
     <Box sx={{ maxWidth: 400, mx: 'auto', mt: 8, p: 2 }}>
       <Typography variant="h4" component="h1" gutterBottom>
-        Iniciar Sesión
+        Registrarse
       </Typography>
       <form onSubmit={handleSubmit}>
         <TextField
@@ -48,6 +60,14 @@ const Login = () => {
           required
         />
         <TextField
+          label="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          fullWidth
+          margin="normal"
+        />
+        <TextField
           label="Contraseña"
           type="password"
           value={password}
@@ -56,9 +76,14 @@ const Login = () => {
           margin="normal"
           required
         />
-        <FormControlLabel
-          control={<Checkbox checked={remember} onChange={(e) => setRemember(e.target.checked)} />}
-          label="Recordar sesión"
+        <TextField
+          label="Confirmar Contraseña"
+          type="password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          fullWidth
+          margin="normal"
+          required
         />
         {error && (
           <Typography color="error" sx={{ mt: 1 }}>
@@ -67,7 +92,7 @@ const Login = () => {
         )}
         <Box sx={{ position: 'relative', mt: 2 }}>
           <Button type="submit" variant="contained" fullWidth disabled={loading}>
-            Entrar
+            Registrarse
           </Button>
           {loading && (
             <CircularProgress size={24} sx={{ position: 'absolute', top: '50%', left: '50%', mt: '-12px', ml: '-12px' }} />
@@ -75,11 +100,10 @@ const Login = () => {
         </Box>
       </form>
       <Typography variant="body2" sx={{ mt: 2 }}>
-        ¿No tienes cuenta?{' '}
-        <Link to="/register">Regístrate</Link>
+        ¿Ya tienes cuenta? <Link to="/login">Iniciar sesión</Link>
       </Typography>
     </Box>
   );
 };
 
-export default Login;
+export default Register;


### PR DESCRIPTION
## Summary
- add RegisterSerializer and RegisterView in the backend
- expose `/api/register/` endpoint
- create registration page in React and wire route
- link home/login pages to registration

## Testing
- `python -m py_compile backend/real_estate/serializers.py backend/real_estate/views.py backend/real_estate/urls.py`
- `node --check frontend/src/pages/Register.jsx` *(fails due to unknown extension)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c140fb548325b76a6cb0a25889d8