### PR TITLE
Add admin property management

### DIFF
--- a/backend/real_estate/migrations/0001_initial.py
+++ b/backend/real_estate/migrations/0001_initial.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Property',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('title', models.CharField(max_length=100)),
+                ('description', models.TextField(blank=True)),
+                ('latitude', models.FloatField()),
+                ('longitude', models.FloatField()),
+                ('owner', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='properties', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/backend/real_estate/models.py
+++ b/backend/real_estate/models.py
@@ -1,6 +1,8 @@
 from django.db import models
+from django.contrib.auth.models import User
 
 class Property(models.Model):
+    owner = models.ForeignKey(User, related_name="properties", on_delete=models.CASCADE)
     title = models.CharField(max_length=100)
     description = models.TextField(blank=True)
     latitude = models.FloatField()

--- a/backend/real_estate/serializers.py
+++ b/backend/real_estate/serializers.py
@@ -10,6 +10,12 @@ class PropertySerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ["id", "email", "first_name", "last_name", "is_staff"]
+
+
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
     """Return token along with basic user information."""
 
@@ -17,6 +23,7 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
     def get_token(cls, user):
         token = super().get_token(user)
         token["username"] = user.username
+        token["is_staff"] = user.is_staff
         return token
 
     def validate(self, attrs):
@@ -25,6 +32,9 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
             "id": self.user.id,
             "username": self.user.username,
             "email": self.user.email,
+            "first_name": self.user.first_name,
+            "last_name": self.user.last_name,
+            "is_staff": self.user.is_staff,
         }
         return data
 
@@ -34,13 +44,15 @@ class RegisterSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ("username", "email", "password")
+        fields = ("email", "password", "first_name", "last_name")
 
     def create(self, validated_data):
         user = User.objects.create_user(
-            username=validated_data["username"],
+            username=validated_data.get("email", ""),
             email=validated_data.get("email", ""),
             password=validated_data["password"],
+            first_name=validated_data.get("first_name", ""),
+            last_name=validated_data.get("last_name", ""),
         )
         return user
 

--- a/backend/real_estate/urls.py
+++ b/backend/real_estate/urls.py
@@ -1,6 +1,6 @@
 from rest_framework.routers import DefaultRouter
 from django.urls import path
-from .views import PropertyViewSet, CustomTokenObtainPairView, RegisterView
+from .views import PropertyViewSet, CustomTokenObtainPairView, RegisterView, UserListView
 
 router = DefaultRouter()
 router.register('properties', PropertyViewSet)
@@ -8,6 +8,7 @@ router.register('properties', PropertyViewSet)
 urlpatterns = [
     path('login/', CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('register/', RegisterView.as_view(), name='register'),
+    path('users/', UserListView.as_view(), name='user_list'),
 ]
 
 urlpatterns += router.urls

--- a/backend/real_estate/views.py
+++ b/backend/real_estate/views.py
@@ -1,18 +1,25 @@
 from rest_framework import viewsets, generics
 from rest_framework_simplejwt.views import TokenObtainPairView
-from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.permissions import IsAuthenticated, AllowAny, IsAdminUser
+from rest_framework.exceptions import PermissionDenied
 from .models import Property
 from django.contrib.auth.models import User
 from .serializers import (
     PropertySerializer,
     CustomTokenObtainPairSerializer,
     RegisterSerializer,
+    UserSerializer,
 )
 
 class PropertyViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = Property.objects.all()
     serializer_class = PropertySerializer
+
+    def perform_create(self, serializer):
+        if not self.request.user.is_staff:
+            raise PermissionDenied("Only admins can create properties")
+        serializer.save()
 
 
 class CustomTokenObtainPairView(TokenObtainPairView):
@@ -23,3 +30,9 @@ class RegisterView(generics.CreateAPIView):
     queryset = User.objects.all()
     serializer_class = RegisterSerializer
     permission_classes = [AllowAny]
+
+
+class UserListView(generics.ListAPIView):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = [IsAdminUser]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,23 +1,23 @@
 import { Routes, Route } from 'react-router-dom';
-import Home from './pages/Home';
 import MapPage from './pages/MapPage';
 import Login from './pages/Login';
 import Register from './pages/Register';
+import Admin from './pages/Admin';
 import PrivateRoute from './PrivateRoute';
 
 const App = () => (
   <Routes>
-    <Route path="/" element={<Home />} />
-    <Route path="/login" element={<Login />} />
-    <Route path="/register" element={<Register />} />
     <Route
-      path="/map"
+      path="/"
       element={(
         <PrivateRoute>
           <MapPage />
         </PrivateRoute>
       )}
     />
+    <Route path="/admin" element={<PrivateRoute><Admin /></PrivateRoute>} />
+    <Route path="/login" element={<Login />} />
+    <Route path="/register" element={<Register />} />
   </Routes>
 );
 

--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -4,29 +4,42 @@ const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(() => localStorage.getItem('token'));
+  const [user, setUser] = useState(() => {
+    const stored =
+      localStorage.getItem('user') || sessionStorage.getItem('user');
+    return stored ? JSON.parse(stored) : null;
+  });
 
-  const login = (newToken, remember) => {
+  const login = (newToken, userData, remember) => {
     if (remember) {
       localStorage.setItem('token', newToken);
+      localStorage.setItem('user', JSON.stringify(userData));
     } else {
       sessionStorage.setItem('token', newToken);
+      sessionStorage.setItem('user', JSON.stringify(userData));
     }
     setToken(newToken);
+    setUser(userData);
   };
 
   const logout = () => {
     localStorage.removeItem('token');
     sessionStorage.removeItem('token');
     setToken(null);
+    setUser(null);
   };
 
   useEffect(() => {
-    const stored = localStorage.getItem('token') || sessionStorage.getItem('token');
-    if (stored) setToken(stored);
+    const storedToken =
+      localStorage.getItem('token') || sessionStorage.getItem('token');
+    const storedUser =
+      localStorage.getItem('user') || sessionStorage.getItem('user');
+    if (storedToken) setToken(storedToken);
+    if (storedUser) setUser(JSON.parse(storedUser));
   }, []);
 
   return (
-    <AuthContext.Provider value={{ token, login, logout }}>
+    <AuthContext.Provider value={{ token, user, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react';
+import { TextField, Button, Box, Typography, MenuItem, Alert } from '@mui/material';
+import { useAuth } from '../AuthContext';
+
+const Admin = () => {
+  const { token, user } = useAuth();
+  const [users, setUsers] = useState([]);
+  const [owner, setOwner] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [lat, setLat] = useState('');
+  const [lng, setLng] = useState('');
+  const [message, setMessage] = useState(null);
+
+  useEffect(() => {
+    if (!user?.is_staff) return;
+    const fetchUsers = async () => {
+      try {
+        const res = await fetch(`${import.meta.env.VITE_API_URL}/users/`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setUsers(data);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchUsers();
+  }, [token, user]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/properties/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({
+          owner,
+          title,
+          description,
+          latitude: parseFloat(lat),
+          longitude: parseFloat(lng)
+        })
+      });
+      if (res.ok) {
+        setMessage('Propiedad creada');
+        setTitle('');
+        setDescription('');
+        setLat('');
+        setLng('');
+      } else {
+        setMessage('Error al crear');
+      }
+    } catch (err) {
+      setMessage('Error al crear');
+    }
+  };
+
+  if (!user?.is_staff) {
+    return (
+      <Typography variant="h6" sx={{ mt: 4, textAlign: 'center' }}>
+        Acceso restringido
+      </Typography>
+    );
+  }
+
+  return (
+    <Box sx={{ maxWidth: 500, mx: 'auto', mt: 4 }}>
+      <Typography variant="h5" gutterBottom>
+        Crear Propiedad
+      </Typography>
+      {message && <Alert severity="info">{message}</Alert>}
+      <form onSubmit={handleSubmit}>
+        <TextField
+          select
+          label="Usuario"
+          value={owner}
+          onChange={(e) => setOwner(e.target.value)}
+          fullWidth
+          margin="normal"
+          required
+        >
+          {users.map((u) => (
+            <MenuItem key={u.id} value={u.id}>{`${u.first_name} ${u.last_name} (${u.email})`}</MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          label="Título"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          fullWidth
+          margin="normal"
+          required
+        />
+        <TextField
+          label="Descripción"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          fullWidth
+          margin="normal"
+        />
+        <TextField
+          label="Latitud"
+          value={lat}
+          onChange={(e) => setLat(e.target.value)}
+          fullWidth
+          margin="normal"
+          required
+        />
+        <TextField
+          label="Longitud"
+          value={lng}
+          onChange={(e) => setLng(e.target.value)}
+          fullWidth
+          margin="normal"
+          required
+        />
+        <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+          Guardar
+        </Button>
+      </form>
+    </Box>
+  );
+};
+
+export default Admin;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -21,7 +21,7 @@ const Home = () => {
       <div style={{ padding: '2rem' }}>
         <h1>Welcome to EstateMap</h1>
         {token ? (
-          <Button component={Link} to="/map" variant="contained" sx={{ mt: 2 }}>
+          <Button component={Link} to="/" variant="contained" sx={{ mt: 2 }}>
             Ir al Mapa
           </Button>
         ) : (

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -6,7 +6,7 @@ import { useAuth } from '../AuthContext';
 const Login = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [remember, setRemember] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -20,12 +20,12 @@ const Login = () => {
       const res = await fetch(`${import.meta.env.VITE_API_URL}/login/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password })
+        body: JSON.stringify({ username: email, password })
       });
       if (!res.ok) throw new Error('Credenciales incorrectas');
       const data = await res.json();
-      login(data.access, remember);
-      navigate('/map');
+      login(data.access, data.user, remember);
+      navigate('/');
     } catch (err) {
       setError(err.message);
     } finally {
@@ -40,9 +40,9 @@ const Login = () => {
       </Typography>
       <form onSubmit={handleSubmit}>
         <TextField
-          label="Usuario"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
+          label="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
           fullWidth
           margin="normal"
           required

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -1,20 +1,45 @@
-import { MapContainer, TileLayer } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import { Button } from '@mui/material';
 import 'leaflet/dist/leaflet.css';
 import { useAuth } from '../AuthContext';
+import { useEffect, useState } from 'react';
 
 const MapPage = () => {
-  const { logout } = useAuth();
+  const { logout, token } = useAuth();
+  const [properties, setProperties] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`${import.meta.env.VITE_API_URL}/properties/`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setProperties(data);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [token]);
+
   return (
     <div style={{ height: '100vh', position: 'relative' }}>
       <Button onClick={logout} variant="contained" sx={{ position: 'absolute', top: 16, right: 16, zIndex: 1000 }}>
         Logout
       </Button>
-      <MapContainer center={[0, 0]} zoom={13} style={{ height: '100%' }}>
+      <MapContainer center={[0, 0]} zoom={3} style={{ height: '100%' }}>
         <TileLayer
           attribution='&copy; OpenStreetMap contributors'
           url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
         />
+        {properties.map((p) => (
+          <Marker key={p.id} position={[p.latitude, p.longitude]}>
+            <Popup>{p.title}</Popup>
+          </Marker>
+        ))}
       </MapContainer>
     </div>
   );

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -6,7 +6,8 @@ import { useAuth } from '../AuthContext';
 const Register = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
-  const [username, setUsername] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
@@ -25,19 +26,19 @@ const Register = () => {
       const res = await fetch(`${import.meta.env.VITE_API_URL}/register/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, email, password })
+        body: JSON.stringify({ email, password, first_name: firstName, last_name: lastName })
       });
       if (!res.ok) throw new Error('Error al registrar');
       // login automatically
       const loginRes = await fetch(`${import.meta.env.VITE_API_URL}/login/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password })
+        body: JSON.stringify({ username: email, password })
       });
       if (!loginRes.ok) throw new Error('Registro completado pero fallo el login');
       const data = await loginRes.json();
-      login(data.access, true);
-      navigate('/map');
+      login(data.access, data.user, true);
+      navigate('/');
     } catch (err) {
       setError(err.message);
     } finally {
@@ -52,9 +53,17 @@ const Register = () => {
       </Typography>
       <form onSubmit={handleSubmit}>
         <TextField
-          label="Usuario"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
+          label="Nombre"
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          fullWidth
+          margin="normal"
+          required
+        />
+        <TextField
+          label="Apellido"
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
           fullWidth
           margin="normal"
           required


### PR DESCRIPTION
## Summary
- extend Property model with owner field
- expose admin-only user list and property creation
- include user details in auth token and store in context
- adjust registration/login to use email, first & last names
- redesign map page to display property markers
- add admin form to assign properties to users
- map page is now the root route

## Testing
- `npm test` *(fails: Missing script)*
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6855ce971ebc8325b88b04a819f60c70