### PR TITLE
feat: add tailwind login and pages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,9 +8,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@emotion/react": "^11.11.4",
-    "@emotion/styled": "^11.11.5",
-    "@mui/material": "^5.15.14",
     "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -19,6 +16,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.4",
     "vite": "^4.5.2"
   },
   "type": "module"

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './AuthContext';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,41 +1,36 @@
 import { Link } from 'react-router-dom';
-import { AppBar, Toolbar, Typography, Button } from '@mui/material';
 import { useAuth } from '../AuthContext';
 
 const Home = () => {
   const { token } = useAuth();
   return (
-    <>
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6" sx={{ flexGrow: 1 }}>
-            EstateMap
-          </Typography>
-          {!token && (
-            <Button color="inherit" component={Link} to="/login">
-              Iniciar Sesión
-            </Button>
-          )}
-        </Toolbar>
-      </AppBar>
-      <div style={{ padding: '2rem' }}>
-        <h1>Welcome to EstateMap</h1>
+    <div>
+      <nav className="bg-blue-600 text-white p-4 flex justify-between">
+        <h1 className="text-lg font-semibold">EstateMap</h1>
+        {!token && (
+          <Link to="/login" className="hover:underline">
+            Iniciar Sesión
+          </Link>
+        )}
+      </nav>
+      <div className="p-8">
+        <h1 className="text-2xl font-bold">Welcome to EstateMap</h1>
         {token ? (
-          <Button component={Link} to="/map" variant="contained" sx={{ mt: 2 }}>
+          <Link to="/map" className="mt-4 inline-block px-4 py-2 bg-blue-600 text-white rounded">
             Ir al Mapa
-          </Button>
+          </Link>
         ) : (
-          <>
-            <Button component={Link} to="/login" variant="contained" sx={{ mt: 2, mr: 2 }}>
+          <div className="mt-4 space-x-2">
+            <Link to="/login" className="px-4 py-2 bg-blue-600 text-white rounded">
               Iniciar Sesión
-            </Button>
-            <Button component={Link} to="/register" variant="outlined" sx={{ mt: 2 }}>
+            </Link>
+            <Link to="/register" className="px-4 py-2 border border-blue-600 text-blue-600 rounded">
               Registrarse
-            </Button>
-          </>
+            </Link>
+          </div>
         )}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { TextField, Button, Checkbox, FormControlLabel, Box, Typography, CircularProgress } from '@mui/material';
 import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 
@@ -34,50 +33,52 @@ const Login = () => {
   };
 
   return (
-    <Box sx={{ maxWidth: 400, mx: 'auto', mt: 8, p: 2 }}>
-      <Typography variant="h4" component="h1" gutterBottom>
-        Iniciar Sesión
-      </Typography>
-      <form onSubmit={handleSubmit}>
-        <TextField
-          label="Usuario"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          fullWidth
-          margin="normal"
-          required
-        />
-        <TextField
-          label="Contraseña"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          fullWidth
-          margin="normal"
-          required
-        />
-        <FormControlLabel
-          control={<Checkbox checked={remember} onChange={(e) => setRemember(e.target.checked)} />}
-          label="Recordar sesión"
-        />
-        {error && (
-          <Typography color="error" sx={{ mt: 1 }}>
-            {error}
-          </Typography>
-        )}
-        <Box sx={{ position: 'relative', mt: 2 }}>
-          <Button type="submit" variant="contained" fullWidth disabled={loading}>
-            Entrar
-          </Button>
-          {loading && (
-            <CircularProgress size={24} sx={{ position: 'absolute', top: '50%', left: '50%', mt: '-12px', ml: '-12px' }} />
-          )}
-        </Box>
+    <div className="max-w-sm mx-auto mt-20 p-6 border rounded">
+      <h1 className="text-2xl font-semibold mb-4 text-center">Iniciar Sesión</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium">Usuario</label>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full mt-1 p-2 border rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Contraseña</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full mt-1 p-2 border rounded"
+            required
+          />
+        </div>
+        <div className="flex items-center">
+          <input
+            id="remember"
+            type="checkbox"
+            checked={remember}
+            onChange={(e) => setRemember(e.target.checked)}
+            className="mr-2"
+          />
+          <label htmlFor="remember">Recordar sesión</label>
+        </div>
+        {error && <p className="text-red-600">{error}</p>}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? 'Cargando...' : 'Entrar'}
+        </button>
       </form>
-      <Button component={Link} to="/register" fullWidth sx={{ mt: 2 }}>
+      <Link to="/register" className="block text-center mt-4 text-blue-600 hover:underline">
         Registrarse
-      </Button>
-    </Box>
+      </Link>
+    </div>
   );
 };
 

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -1,16 +1,18 @@
 import { MapContainer, TileLayer } from 'react-leaflet';
-import { Button } from '@mui/material';
 import 'leaflet/dist/leaflet.css';
 import { useAuth } from '../AuthContext';
 
 const MapPage = () => {
   const { logout } = useAuth();
   return (
-    <div style={{ height: '100vh', position: 'relative' }}>
-      <Button onClick={logout} variant="contained" sx={{ position: 'absolute', top: 16, right: 16, zIndex: 1000 }}>
+    <div className="h-screen relative">
+      <button
+        onClick={logout}
+        className="absolute top-4 right-4 z-[1000] px-4 py-2 bg-blue-600 text-white rounded"
+      >
         Logout
-      </Button>
-      <MapContainer center={[0, 0]} zoom={13} style={{ height: '100%' }}>
+      </button>
+      <MapContainer center={[0, 0]} zoom={13} className="h-full w-full">
         <TileLayer
           attribution='&copy; OpenStreetMap contributors'
           url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { TextField, Button, Box, Typography, CircularProgress } from '@mui/material';
 import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 
@@ -28,7 +27,6 @@ const Register = () => {
         body: JSON.stringify({ username, email, password })
       });
       if (!res.ok) throw new Error('Error al registrar');
-      // login automatically
       const loginRes = await fetch(`${import.meta.env.VITE_API_URL}/login/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -46,63 +44,61 @@ const Register = () => {
   };
 
   return (
-    <Box sx={{ maxWidth: 400, mx: 'auto', mt: 8, p: 2 }}>
-      <Typography variant="h4" component="h1" gutterBottom>
-        Registrarse
-      </Typography>
-      <form onSubmit={handleSubmit}>
-        <TextField
-          label="Usuario"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          fullWidth
-          margin="normal"
-          required
-        />
-        <TextField
-          label="Email"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          fullWidth
-          margin="normal"
-        />
-        <TextField
-          label="Contraseña"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          fullWidth
-          margin="normal"
-          required
-        />
-        <TextField
-          label="Confirmar Contraseña"
-          type="password"
-          value={confirm}
-          onChange={(e) => setConfirm(e.target.value)}
-          fullWidth
-          margin="normal"
-          required
-        />
-        {error && (
-          <Typography color="error" sx={{ mt: 1 }}>
-            {error}
-          </Typography>
-        )}
-        <Box sx={{ position: 'relative', mt: 2 }}>
-          <Button type="submit" variant="contained" fullWidth disabled={loading}>
-            Registrarse
-          </Button>
-          {loading && (
-            <CircularProgress size={24} sx={{ position: 'absolute', top: '50%', left: '50%', mt: '-12px', ml: '-12px' }} />
-          )}
-        </Box>
+    <div className="max-w-sm mx-auto mt-20 p-6 border rounded">
+      <h1 className="text-2xl font-semibold mb-4 text-center">Registrarse</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium">Usuario</label>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full mt-1 p-2 border rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full mt-1 p-2 border rounded"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Contraseña</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full mt-1 p-2 border rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Confirmar Contraseña</label>
+          <input
+            type="password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            className="w-full mt-1 p-2 border rounded"
+            required
+          />
+        </div>
+        {error && <p className="text-red-600">{error}</p>}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? 'Cargando...' : 'Registrarse'}
+        </button>
       </form>
-      <Typography variant="body2" sx={{ mt: 2 }}>
-        ¿Ya tienes cuenta? <Link to="/login">Iniciar sesión</Link>
-      </Typography>
-    </Box>
+      <p className="text-sm text-center mt-4">
+        ¿Ya tienes cuenta? <Link to="/login" className="text-blue-600 hover:underline">Iniciar sesión</Link>
+      </p>
+    </div>
   );
 };
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,jsx,ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- replace MUI with Tailwind CSS and add Tailwind configuration
- implement login, register, home, and map pages using Tailwind styles
- add base Tailwind styles and setup

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm run build` *(fails: vite: not found)*
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b87c68973483258d5b71a2f315be82