### PR TITLE
fix: fallback API url for auth pages

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -5,6 +5,7 @@ import { useAuth } from '../AuthContext';
 const Login = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
+  const API_URL = import.meta.env.VITE_API_URL || '/api';
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [remember, setRemember] = useState(false);
@@ -16,7 +17,7 @@ const Login = () => {
     setError(null);
     setLoading(true);
     try {
-      const res = await fetch(`${import.meta.env.VITE_API_URL}/login/`, {
+      const res = await fetch(`${API_URL}/login/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -5,6 +5,7 @@ import { useAuth } from '../AuthContext';
 const Register = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
+  const API_URL = import.meta.env.VITE_API_URL || '/api';
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -21,13 +22,13 @@ const Register = () => {
     setError(null);
     setLoading(true);
     try {
-      const res = await fetch(`${import.meta.env.VITE_API_URL}/register/`, {
+      const res = await fetch(`${API_URL}/register/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, email, password })
       });
       if (!res.ok) throw new Error('Error al registrar');
-      const loginRes = await fetch(`${import.meta.env.VITE_API_URL}/login/`, {
+      const loginRes = await fetch(`${API_URL}/login/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })


### PR DESCRIPTION
## Summary
- ensure login and registration use a valid API base even when `VITE_API_URL` is not provided

## Testing
- `npm test` *(fails: Missing script "test")*
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b897ea054483258d4ddc6155c3f3f1