### PR TITLE
feat: support email login and global layout

### DIFF
--- a/backend/real_estate/serializers.py
+++ b/backend/real_estate/serializers.py
@@ -20,6 +20,18 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
         return token
 
     def validate(self, attrs):
+        # Allow login using email instead of username
+        email = attrs.get("email")
+        password = attrs.get("password")
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            raise serializers.ValidationError("No active account found with the given credentials")
+
+        # Replace email with the resolved username for the parent validation
+        attrs["username"] = user.username
+        del attrs["email"]
+
         data = super().validate(attrs)
         data["user"] = {
             "id": self.user.id,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EstateMap</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,21 +4,28 @@ import MapPage from './pages/MapPage';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import PrivateRoute from './PrivateRoute';
-
+import NavBar from './components/NavBar';
+import Footer from './components/Footer';
 const App = () => (
-  <Routes>
-    <Route path="/" element={<Home />} />
-    <Route path="/login" element={<Login />} />
-    <Route path="/register" element={<Register />} />
-    <Route
-      path="/map"
-      element={(
-        <PrivateRoute>
-          <MapPage />
-        </PrivateRoute>
-      )}
-    />
-  </Routes>
+  <div className="min-h-screen flex flex-col bg-background text-textPrimary font-sans">
+    <NavBar />
+    <main className="flex-grow">
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+        <Route
+          path="/map"
+          element={(
+            <PrivateRoute>
+              <MapPage />
+            </PrivateRoute>
+          )}
+        />
+      </Routes>
+    </main>
+    <Footer />
+  </div>
 );
 
 export default App;

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,0 +1,7 @@
+const Footer = () => (
+  <footer className="bg-dark text-textSecondary text-center p-4">
+    © {new Date().getFullYear()} EstateMap. Todos los derechos reservados.
+  </footer>
+);
+
+export default Footer;

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
+
+const NavBar = () => {
+  const { token, logout } = useAuth();
+  return (
+    <nav className="bg-primary text-white p-4 flex justify-between items-center">
+      <Link to="/" className="text-xl font-semibold">EstateMap</Link>
+      {token ? (
+        <button onClick={logout} className="hover:text-secondary transition-colors">Salir</button>
+      ) : (
+        <div className="space-x-4">
+          <Link to="/login" className="hover:text-secondary transition-colors">Iniciar Sesión</Link>
+          <Link to="/register" className="hover:text-secondary transition-colors">Registrarse</Link>
+        </div>
+      )}
+    </nav>
+  );
+};
+
+export default NavBar;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,19 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-background text-textPrimary font-sans;
+}
+
+.custom-marker {
+  background-color: #1E3A8A;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 9999px;
+  border: 2px solid white;
+}
+
+.custom-marker:hover {
+  background-color: #F59E0B;
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,32 +4,22 @@ import { useAuth } from '../AuthContext';
 const Home = () => {
   const { token } = useAuth();
   return (
-    <div>
-      <nav className="bg-blue-600 text-white p-4 flex justify-between">
-        <h1 className="text-lg font-semibold">EstateMap</h1>
-        {!token && (
-          <Link to="/login" className="hover:underline">
+    <div className="p-8 text-center">
+      <h1 className="text-3xl font-bold mb-4">Bienvenido a EstateMap</h1>
+      {token ? (
+        <Link to="/map" className="mt-4 inline-block px-6 py-3 bg-primary text-white rounded-2xl shadow-lg hover:bg-secondary transition-all">
+          Ir al Mapa
+        </Link>
+      ) : (
+        <div className="mt-4 space-x-2">
+          <Link to="/login" className="px-4 py-2 bg-primary text-white rounded-2xl shadow-lg hover:bg-secondary transition-all">
             Iniciar Sesión
           </Link>
-        )}
-      </nav>
-      <div className="p-8">
-        <h1 className="text-2xl font-bold">Welcome to EstateMap</h1>
-        {token ? (
-          <Link to="/map" className="mt-4 inline-block px-4 py-2 bg-blue-600 text-white rounded">
-            Ir al Mapa
+          <Link to="/register" className="px-4 py-2 border-2 border-primary text-primary rounded-2xl hover:bg-primary hover:text-white transition-all">
+            Registrarse
           </Link>
-        ) : (
-          <div className="mt-4 space-x-2">
-            <Link to="/login" className="px-4 py-2 bg-blue-600 text-white rounded">
-              Iniciar Sesión
-            </Link>
-            <Link to="/register" className="px-4 py-2 border border-blue-600 text-blue-600 rounded">
-              Registrarse
-            </Link>
-          </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -6,7 +6,7 @@ const Login = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
   const API_URL = import.meta.env.VITE_API_URL || '/api';
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [remember, setRemember] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -20,7 +20,7 @@ const Login = () => {
       const res = await fetch(`${API_URL}/login/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password })
+        body: JSON.stringify({ email, password })
       });
       if (!res.ok) throw new Error('Credenciales incorrectas');
       const data = await res.json();
@@ -34,15 +34,15 @@ const Login = () => {
   };
 
   return (
-    <div className="max-w-sm mx-auto mt-20 p-6 border rounded">
+    <div className="max-w-sm mx-auto mt-20 p-6 bg-white rounded-2xl shadow-lg">
       <h1 className="text-2xl font-semibold mb-4 text-center">Iniciar Sesión</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium">Usuario</label>
+          <label className="block text-sm font-medium">Correo electrónico</label>
           <input
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
             className="w-full mt-1 p-2 border rounded"
             required
           />
@@ -67,16 +67,16 @@ const Login = () => {
           />
           <label htmlFor="remember">Recordar sesión</label>
         </div>
-        {error && <p className="text-red-600">{error}</p>}
+        {error && <p className="text-error">{error}</p>}
         <button
           type="submit"
           disabled={loading}
-          className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+          className="w-full py-2 bg-primary text-white rounded-2xl hover:bg-secondary disabled:opacity-50 transition-all"
         >
           {loading ? 'Cargando...' : 'Entrar'}
         </button>
       </form>
-      <Link to="/register" className="block text-center mt-4 text-blue-600 hover:underline">
+      <Link to="/register" className="block text-center mt-4 text-primary hover:underline">
         Registrarse
       </Link>
     </div>

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -1,23 +1,26 @@
-import { MapContainer, TileLayer } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
-import { useAuth } from '../AuthContext';
+import L from 'leaflet';
+
+const icon = L.divIcon({ className: 'custom-marker' });
 
 const MapPage = () => {
-  const { logout } = useAuth();
   return (
-    <div className="h-screen relative">
-      <button
-        onClick={logout}
-        className="absolute top-4 right-4 z-[1000] px-4 py-2 bg-blue-600 text-white rounded"
-      >
-        Logout
-      </button>
+    <div className="grid grid-cols-1 lg:grid-cols-2 h-screen">
       <MapContainer center={[0, 0]} zoom={13} className="h-full w-full">
         <TileLayer
           attribution='&copy; OpenStreetMap contributors'
           url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
         />
+        <Marker position={[0, 0]} icon={icon}>
+          <Popup>Propiedad demo</Popup>
+        </Marker>
       </MapContainer>
+      <div className="bg-dark text-white overflow-y-auto p-4 space-y-4">
+        <div className="bg-white text-textPrimary rounded-2xl shadow-lg p-4 transition-all hover:scale-105">
+          Propiedad demo
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -31,7 +31,7 @@ const Register = () => {
       const loginRes = await fetch(`${API_URL}/login/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password })
+        body: JSON.stringify({ email, password })
       });
       if (!loginRes.ok) throw new Error('Registro completado pero fallo el login');
       const data = await loginRes.json();
@@ -45,7 +45,7 @@ const Register = () => {
   };
 
   return (
-    <div className="max-w-sm mx-auto mt-20 p-6 border rounded">
+    <div className="max-w-sm mx-auto mt-20 p-6 bg-white rounded-2xl shadow-lg">
       <h1 className="text-2xl font-semibold mb-4 text-center">Registrarse</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
@@ -87,17 +87,17 @@ const Register = () => {
             required
           />
         </div>
-        {error && <p className="text-red-600">{error}</p>}
+        {error && <p className="text-error">{error}</p>}
         <button
           type="submit"
           disabled={loading}
-          className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+          className="w-full py-2 bg-primary text-white rounded-2xl hover:bg-secondary disabled:opacity-50 transition-all"
         >
           {loading ? 'Cargando...' : 'Registrarse'}
         </button>
       </form>
       <p className="text-sm text-center mt-4">
-        ¿Ya tienes cuenta? <Link to="/login" className="text-blue-600 hover:underline">Iniciar sesión</Link>
+        ¿Ya tienes cuenta? <Link to="/login" className="text-primary hover:underline">Iniciar sesión</Link>
       </p>
     </div>
   );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,7 +4,21 @@ export default {
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Poppins', 'sans-serif'],
+      },
+      colors: {
+        primary: '#1E3A8A',
+        secondary: '#F59E0B',
+        background: '#F9FAFB',
+        dark: '#111827',
+        textPrimary: '#111827',
+        textSecondary: '#6B7280',
+        success: '#10B981',
+        error: '#EF4444',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- allow backend to authenticate using email
- use email-based login on frontend and apply premium color palette
- add global navigation bar and footer with custom styling
- introduce map/sidebar layout with custom markers

## Testing
- `python manage.py check`
- `npm run build` *(fails: vite not found / package install restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68b89b056bbc8325b30810c1868b5661