### PR TITLE
Integrate Formik and toast notifications for auth forms

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,10 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-leaflet": "^4.3.1",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "formik": "^2.4.5",
+    "yup": "^1.3.0",
+    "react-toastify": "^10.0.4"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Register from './pages/Register';
 import PrivateRoute from './PrivateRoute';
 import NavBar from './components/NavBar';
 import Footer from './components/Footer';
+import { ToastContainer } from 'react-toastify';
 const App = () => (
   <div className="min-h-screen flex flex-col bg-background text-textPrimary font-sans">
     <NavBar />
@@ -25,6 +26,7 @@ const App = () => (
       </Routes>
     </main>
     <Footer />
+    <ToastContainer position="top-right" autoClose={3000} hideProgressBar />
   </div>
 );
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './AuthContext';
 import './index.css';
+import 'react-toastify/dist/ReactToastify.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,101 +1,117 @@
-import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
+import { Formik, Form, Field, ErrorMessage } from 'formik';
+import * as Yup from 'yup';
+import { toast } from 'react-toastify';
 
 const Register = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
   const API_URL = import.meta.env.VITE_API_URL || '/api';
-  const [username, setUsername] = useState('');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirm, setConfirm] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (password !== confirm) {
-      setError('Las contraseñas no coinciden');
-      return;
-    }
-    setError(null);
-    setLoading(true);
+  const validationSchema = Yup.object({
+    username: Yup.string().required('Campo requerido'),
+    email: Yup.string().email('Correo inválido').required('Campo requerido'),
+    password: Yup.string().required('Campo requerido'),
+    confirm: Yup.string()
+      .oneOf([Yup.ref('password'), null], 'Las contraseñas no coinciden')
+      .required('Campo requerido'),
+  });
+
+  const handleSubmit = async (values, { setSubmitting }) => {
     try {
       const res = await fetch(`${API_URL}/register/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, email, password })
+        body: JSON.stringify({ username: values.username, email: values.email, password: values.password }),
       });
-      if (!res.ok) throw new Error('Error al registrar');
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast.error(data.detail || 'Error al registrar');
+        setSubmitting(false);
+        return;
+      }
       const loginRes = await fetch(`${API_URL}/login/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
+        body: JSON.stringify({ email: values.email, password: values.password }),
       });
-      if (!loginRes.ok) throw new Error('Registro completado pero fallo el login');
-      const data = await loginRes.json();
-      login(data.access, true);
+      const loginData = await loginRes.json().catch(() => ({}));
+      if (!loginRes.ok) {
+        toast.error(loginData.detail || 'Registro completado pero fallo el login');
+        setSubmitting(false);
+        return;
+      }
+      login(loginData.access, true);
+      toast.success('Registro exitoso');
       navigate('/map');
     } catch (err) {
-      setError(err.message);
+      toast.error('Error de conexión');
     } finally {
-      setLoading(false);
+      setSubmitting(false);
     }
   };
 
   return (
     <div className="max-w-sm mx-auto mt-20 p-6 bg-white rounded-2xl shadow-lg">
       <h1 className="text-2xl font-semibold mb-4 text-center">Registrarse</h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className="block text-sm font-medium">Usuario</label>
-          <input
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            className="w-full mt-1 p-2 border rounded"
-            required
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium">Email</label>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="w-full mt-1 p-2 border rounded"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium">Contraseña</label>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="w-full mt-1 p-2 border rounded"
-            required
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium">Confirmar Contraseña</label>
-          <input
-            type="password"
-            value={confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-            className="w-full mt-1 p-2 border rounded"
-            required
-          />
-        </div>
-        {error && <p className="text-error">{error}</p>}
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full py-2 bg-primary text-white rounded-2xl hover:bg-secondary disabled:opacity-50 transition-all"
-        >
-          {loading ? 'Cargando...' : 'Registrarse'}
-        </button>
-      </form>
+      <Formik
+        initialValues={{ username: '', email: '', password: '', confirm: '' }}
+        validationSchema={validationSchema}
+        onSubmit={handleSubmit}
+      >
+        {({ isSubmitting }) => (
+          <Form className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium" htmlFor="username">Usuario</label>
+              <Field
+                id="username"
+                name="username"
+                type="text"
+                className="w-full mt-1 p-2 border rounded"
+              />
+              <ErrorMessage name="username" component="p" className="text-error" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium" htmlFor="email">Email</label>
+              <Field
+                id="email"
+                name="email"
+                type="email"
+                className="w-full mt-1 p-2 border rounded"
+              />
+              <ErrorMessage name="email" component="p" className="text-error" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium" htmlFor="password">Contraseña</label>
+              <Field
+                id="password"
+                name="password"
+                type="password"
+                className="w-full mt-1 p-2 border rounded"
+              />
+              <ErrorMessage name="password" component="p" className="text-error" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium" htmlFor="confirm">Confirmar Contraseña</label>
+              <Field
+                id="confirm"
+                name="confirm"
+                type="password"
+                className="w-full mt-1 p-2 border rounded"
+              />
+              <ErrorMessage name="confirm" component="p" className="text-error" />
+            </div>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full py-2 bg-primary text-white rounded-2xl hover:bg-secondary disabled:opacity-50 transition-all"
+            >
+              {isSubmitting ? 'Cargando...' : 'Registrarse'}
+            </button>
+          </Form>
+        )}
+      </Formik>
       <p className="text-sm text-center mt-4">
         ¿Ya tienes cuenta? <Link to="/login" className="text-primary hover:underline">Iniciar sesión</Link>
       </p>
@@ -104,3 +120,4 @@ const Register = () => {
 };
 
 export default Register;
+


### PR DESCRIPTION
## Summary
- add Formik, Yup, and React-Toastify dependencies
- convert login and register forms to Formik with validation and toasts
- provide global ToastContainer for app-wide notifications

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b8a9c304a88325a4c72d959b85c63d